### PR TITLE
Hotfix converter default compression

### DIFF
--- a/src/main/java/ru/itmo/ctlab/hict/hict_server/handlers/conversion/ConversionHandlersHolder.java
+++ b/src/main/java/ru/itmo/ctlab/hict/hict_server/handlers/conversion/ConversionHandlersHolder.java
@@ -69,7 +69,7 @@ public class ConversionHandlersHolder extends HandlersHolder {
 
               final var resolutionCsv = req.getParam("resolutions");
               final var resolutions = parseResolutions(resolutionCsv);
-              final var compression = parseInteger(req.getParam("compression"), 0);
+              final var compression = parseInteger(req.getParam("compression"), 6);
               final var compressionAlgorithm = ConversionOptions.CompressionAlgorithm.parse(req.getParam("compressionAlgorithm") == null ? "deflate" : req.getParam("compressionAlgorithm"));
               final var chunkSize = parseInteger(req.getParam("chunkSize"), 8192);
               final var applyAgpRaw = Boolean.parseBoolean(req.getParam("applyAgp"));
@@ -99,7 +99,7 @@ public class ConversionHandlersHolder extends HandlersHolder {
             final var direction = requestJson.getString("direction", "mcool-to-hict");
             final var parallelism = requestJson.getInteger("parallelism", Runtime.getRuntime().availableProcessors());
             final var resolutions = parseResolutions(requestJson.getString("resolutions"));
-            final var compression = requestJson.getInteger("compression", 0);
+            final var compression = requestJson.getInteger("compression", 6);
             final var compressionAlgorithm = ConversionOptions.CompressionAlgorithm.parse(requestJson.getString("compressionAlgorithm", "deflate"));
             final var chunkSize = requestJson.getInteger("chunkSize", 8192);
 
@@ -143,7 +143,7 @@ public class ConversionHandlersHolder extends HandlersHolder {
             final var parallelJobs = Math.max(1, requestJson.getInteger("parallelJobs", 1));
             final var parallelism = requestJson.getInteger("parallelism", Runtime.getRuntime().availableProcessors());
             final var resolutions = parseResolutions(requestJson.getString("resolutions"));
-            final var compression = requestJson.getInteger("compression", 0);
+            final var compression = requestJson.getInteger("compression", 6);
             final var compressionAlgorithm = ConversionOptions.CompressionAlgorithm.parse(requestJson.getString("compressionAlgorithm", "deflate"));
             final var chunkSize = requestJson.getInteger("chunkSize", 8192);
 

--- a/src/main/java/ru/itmo/ctlab/hict/hict_server/tools/ConversionCliLauncher.java
+++ b/src/main/java/ru/itmo/ctlab/hict/hict_server/tools/ConversionCliLauncher.java
@@ -29,7 +29,7 @@ public class ConversionCliLauncher {
       Path.of(parser.require("output")),
       parser.listOfLong("resolutions"),
       parser.integer("chunk-size", 8192),
-      parser.integer("compression", 0),
+      parser.integer("compression", 6),
       ConversionOptions.CompressionAlgorithm.parse(parser.value("compression-algorithm", "deflate")),
       parser.value("agp", ConversionOptions.NO_AGP),
       parser.flag("apply-agp"),
@@ -54,8 +54,8 @@ public class ConversionCliLauncher {
 
   private static void printHelp() {
     System.out.println("Usage:");
-    System.out.println("  hict-to-mcool --input=<in.hict> --output=<out.mcool> [--resolutions=10000,50000] [--compression=0..9] [--compression-algorithm=deflate|zstd|lzf] [--chunk-size=8192] [--agp=foo.agp --apply-agp] [--parallelism=N]");
-    System.out.println("  mcool-to-hict --input=<in.mcool> --output=<out.hict> [--resolutions=10000,50000] [--compression=0..9] [--compression-algorithm=deflate|zstd|lzf] [--chunk-size=8192] [--parallelism=N]");
+    System.out.println("  hict-to-mcool --input=<in.hict> --output=<out.mcool> [--resolutions=10000,50000] [--compression=0..9 (default: 6)] [--compression-algorithm=deflate|zstd|lzf] [--chunk-size=8192] [--agp=foo.agp --apply-agp] [--parallelism=N]");
+    System.out.println("  mcool-to-hict --input=<in.mcool> --output=<out.hict> [--resolutions=10000,50000] [--compression=0..9 (default: 6)] [--compression-algorithm=deflate|zstd|lzf] [--chunk-size=8192] [--parallelism=N]");
   }
 
   private record ArgParser(String[] args) {

--- a/src/main/java/ru/itmo/ctlab/hict/hict_server/tools/HictCli.java
+++ b/src/main/java/ru/itmo/ctlab/hict/hict_server/tools/HictCli.java
@@ -122,7 +122,7 @@ public class HictCli implements Runnable {
     @Option(names = "--chunk-size", defaultValue = "8192", description = "HDF5 chunk size (default: 8192).")
     int chunkSize;
 
-    @Option(names = "--compression", defaultValue = "0", description = "Compression level 0..9 (default: 0).")
+    @Option(names = "--compression", defaultValue = "6", description = "Compression level 0..9 (default: 6).")
     int compression;
 
     @Option(


### PR DESCRIPTION
Hotfix: enable Deflate compression level 6 by default in .mcool -> .hict.hdf5 converter, otherwise it might produce huge HDF5 files.